### PR TITLE
SubStractCaptureImageサンプルコンポーネントの修正　Issue#14

### DIFF
--- a/opencv/components/SubStractCaptureImage/src/SubStractCaptureImage.cpp
+++ b/opencv/components/SubStractCaptureImage/src/SubStractCaptureImage.cpp
@@ -261,9 +261,9 @@ RTC::ReturnCode_t SubStractCaptureImage::onExecute(RTC::UniqueId ec_id)
       /* 背景に同化する場合 (backgroundMaskImage=1の場合) */
 	  
 	  
-	  cv::accumulateWeighted(backgroundAverageImage, frameImage32, BACKGROUND_ALPHA, backgroundMaskImage);
+	  cv::accumulateWeighted(frameImage32, backgroundAverageImage, BACKGROUND_ALPHA, backgroundMaskImage);
 
-	  cv::accumulateWeighted(backgroundThresholdImage, backgroundDifferenceImage, BACKGROUND_ALPHA, backgroundMaskImage);
+	  cv::accumulateWeighted( backgroundDifferenceImage, backgroundThresholdImage, BACKGROUND_ALPHA, backgroundMaskImage);
 	  
       /* 背景候補に同化する場合 (backgroundMaskImage=0 && stillObjectMaskImage=1) */
 	  cv::bitwise_not(backgroundMaskImage, foregroundMaskImage);
@@ -336,8 +336,8 @@ RTC::ReturnCode_t SubStractCaptureImage::onExecute(RTC::UniqueId ec_id)
       /* ノイズを除去する */
 	  cv::medianBlur(foregroundMaskImage, foregroundMaskImage, 7);
 
-	  backgroundAverageImage.convertTo(backgroundImage, CV_32F);
-	  stillObjectAverageImage.convertTo(stillObjectImage, CV_32F);
+	  backgroundAverageImage.convertTo(backgroundImage, CV_8UC3);
+	  stillObjectAverageImage.convertTo(stillObjectImage, CV_8UC3);
 
 
       cvWaitKey( 1 );


### PR DESCRIPTION


<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug
#14 


## Description of the Change
* backGroundImgの出力のデータフォーマットをCV_32FからCV_8UC3に変更
* stillImgの出力のデータフォーマットをCV_32FからCV_8UC3に変更
* accumulateWeighted関数のsrcとdstのパラメータが逆だった箇所が2か所あったのでそれを修正

## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [X] Did you succesed the build?  
- [ ] No warnings for the build?  C4244のエラーがいくつか表示、ビルドは正常に終了
- [X] Have you passed the unit tests?  ユニットテストが一般的なモジュールのテストということならば、動作させて添付のファイルのような出力を得られました。（ただStillMaskImgの出力はちょっと不安がありますが、他が正しく動作しているようなので、一応ここでPRします。）
![SubstractCaptureafterFix](https://user-images.githubusercontent.com/52995055/73724610-0a6bcb80-476f-11ea-9cf3-5a14efb85eba.png)

