### PR TITLE
masterブランチのバージョン番号を1.2.2へ更新する

### DIFF
--- a/opencv/CMakeLists.txt
+++ b/opencv/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
 
 project(ImageProcessing)
-set(PROJECT_VERSION 1.2.1 CACHE STRING "ImageProcessing version")
+set(PROJECT_VERSION 1.2.2 CACHE STRING "ImageProcessing version")
 set(TOP_PROJECT_NAME ${PROJECT_NAME})
 string(TOLOWER ${TOP_PROJECT_NAME} TOP_PROJECT_NAME_LOWER)
 SUBDIRS(components)


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Link to #18 


## Description of the Change

-  ImageProcessing全体のバージョン番号を 1.2.2 へ更新した
- この変更により、Linux環境で下記ファイル名のdebパッケージが生成される
「imageprocessing_1.2.2_amd64.deb」
- ImageProcessingの各RTC個別のバージョン番号は更新していない

## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succesed the build?  
- [ ] No warnings for the build?  
- [ ] Have you passed the unit tests?  
- components/TkCalibGUIのcmake時に「Policy CMP0048」のワーニングが出ている
- TkCalibGUIのLinux環境での実行については、RTC生成時と環境が変わっているので別途確認、対応が必要と思われる。Windows環境用にはexe化するので問題なく動作するはず。ということで、とりあえずソースはこのままとした。