### PR TITLE
Bugfix in tkcalibgui on python3

### DIFF
--- a/opencv/components/TkCalibGUI/TkCalibGUIComp.py
+++ b/opencv/components/TkCalibGUI/TkCalibGUIComp.py
@@ -13,26 +13,41 @@ def check_openrtmpy():
         import OpenRTM_aist
         print("OpenRTM python is installed.")
     except:
-        import tkMessageBox
-        import Tkinter
+        if sys.version_info[0] == 2:
+            import tkMessageBox
+            import Tkinter
+        else:
+            from tkinter import messagebox as tkMessageBox
         msg = u'OpenRTM-aist Python is not installed. '
         msg += u'Please download it from \n'
         msg += u'http://openrtm.org/openrtm/ja/content/tkcalibgui'
-        Tkinter.Tk().withdraw()
+        if sys.version_info[0] == 2:
+            Tkinter.Tk().withdraw()
+        else:
+            tkinter.Tk().withdraw()
         tkMessageBox.showerror(title = "OpenRTM not found",
                   message = msg)
 
 def check_ttk():
     try:
-        import ttk
+        if sys.version_info[0] == 2:
+            import ttk
+        else:
+            import tkinter.ttk as ttk
         print("Ttk is installed.")
     except:
-        import tkMessageBox
-        import Tkinter
+        if sys.version_info[0] == 2:
+            import tkMessageBox
+            import Tkinter
+        else:
+            from tkinter import messagebox as tkMessageBox
         msg = u'Ttk is not installed. '
         msg += u'Please download it from \n'
         msg += u'http://openrtm.org/openrtm/ja/content/tkcalibgui'
-        Tkinter.Tk().withdraw()
+        if sys.version_info[0] == 2:
+            Tkinter.Tk().withdraw()
+        else:
+            tkinter.Tk().withdraw()
         tkMessageBox.showerror(title = "Ttk not found",
                   message = msg)
 
@@ -41,12 +56,18 @@ def check_pil():
         from PIL import Image, ImageTk
         print("Python Imaging Library (PIL) is installed.")
     except:
-        import tkMessageBox
-        import Tkinter
+        if sys.version_info[0] == 2:
+            import tkMessageBox
+            import Tkinter
+        else:
+            from tkinter import messagebox as tkMessageBox
         msg = u'Python Imaging Library (PIL) is not installed. '
         msg += u'Please download it from \n'
         msg += u'http://openrtm.org/openrtm/ja/content/tkcalibgui'
-        Tkinter.Tk().withdraw()
+        if sys.version_info[0] == 2:
+            Tkinter.Tk().withdraw()
+        else:
+            tkinter.Tk().withdraw()
         tkMessageBox.showerror(title = "PIL not found",
                   message = msg)
 
@@ -55,12 +76,18 @@ def check_numpy():
         import numpy
         print("Numpy is installed.")
     except:
-        import tkMessageBox
-        import Tkinter
+        if sys.version_info[0] == 2:
+            import tkMessageBox
+            import Tkinter
+        else:
+            from tkinter import messagebox as tkMessageBox
         msg = u'Numpy is not installed. '
         msg += u'Please download it from \n'
         msg += u'http://openrtm.org/openrtm/ja/content/tkcalibgui'
-        Tkinter.Tk().withdraw()
+        if sys.version_info[0] == 2:
+            Tkinter.Tk().withdraw()
+        else:
+            tkinter.Tk().withdraw()
         tkMessageBox.showerror(title = "Numpy not found",
                   message = msg)
                   
@@ -69,16 +96,24 @@ def check_rtctree():
         import rtctree
         print("rtctree is installed.")
     except:
-        import tkMessageBox
-        import Tkinter
+        if sys.version_info[0] == 2:
+            import tkMessageBox
+            import Tkinter
+        else:
+            from tkinter import messagebox as tkMessageBox
         msg = u'rtctree is not installed. '
         msg += u'Please download it from \n'
         msg += u'http://openrtm.org/openrtm/ja/content/tkcalibgui'
-        Tkinter.Tk().withdraw()
+        if sys.version_info[0] == 2:
+            Tkinter.Tk().withdraw()
+        else:
+            tkinter.Tk().withdraw()
         tkMessageBox.showerror(title = "rtctree not found",
                   message = msg)
         return
 		
+import sys
+
 # check execution condition
 check_openrtmpy()
 check_pil()
@@ -87,7 +122,6 @@ check_numpy()
 check_rtctree()
 
 import os
-import sys
 import socket
 import getopt
 import re

--- a/opencv/components/TkCalibGUI/tkcalibgui.py
+++ b/opencv/components/TkCalibGUI/tkcalibgui.py
@@ -1383,9 +1383,7 @@ AAAqAAIYAAAAqAAIYAAAAKACIIABAACACoAABgAAACoAAhgAAACoAAhgAAAAoAIg
 gAEAAIAKgAAGAAAAKgACGAAAAKiA/wdXr6Z02sdfbwAAAABJRU5ErkJggg=="""
 	def __init__(self):
 		import binascii
-		self.buff = ''
-		for l in self.logo.split("\n"):
-			self.buff += binascii.a2b_base64(l)	
+		self.buff = b"".join([binascii.a2b_base64(l) for l in self.logo.split("\n")])
 	def get_image(self):
 		return self.buff
 		
@@ -1393,5 +1391,5 @@ gAEAAIAKgAAGAAAAKgACGAAAAKiA/wdXr6Z02sdfbwAAAABJRU5ErkJggg=="""
 
 if __name__ == "__main__":
 	RTMLogo()
-#	f = TkCalibGUI()
-#	f.mainloop()
+	f = TkCalibGUI()
+	f.mainloop()

--- a/opencv/components/TkCalibGUI/tkcalibgui.py
+++ b/opencv/components/TkCalibGUI/tkcalibgui.py
@@ -9,16 +9,24 @@
 
 
 """
-from Tkinter import *
-import ttk
+import sys
+if sys.version_info[0] == 2:
+  from Tkinter import *
+  import ttk
+else:
+  from tkinter import *
+  import tkinter.ttk as ttk
+
 from PIL import Image, ImageTk
 import time
-import sys
 import os.path
 #from cv2.cv import *
 import numpy
 from io import BytesIO
-from StringIO import StringIO
+if sys.version_info[0] == 2:
+  from StringIO import StringIO
+else:
+  from io import StringIO
 from threading import Thread
 
 import rtutil
@@ -123,7 +131,10 @@ class TkCalibGUI(Frame):
 	# check build camera component
 	def check_camera_comp(self):
 		camera_list = self.get_avail_camera_list()
-		self.select_camera_list = self.get_comp_path(camera_list)
+		if sys.version_info[0] == 2:
+			self.select_camera_list = self.get_comp_path(camera_list)
+		else:
+			self.select_camera_list = self.get_comp_path(list(camera_list))
 		
 	def get_comp_path(self, comp_name):
 		import platform
@@ -189,7 +200,11 @@ class TkCalibGUI(Frame):
 		self.fix1.pack(fill=X, ipadx=3, ipady=3)	
 		lb = Label(self.fix1, text=self.msg10)
 		lb.grid(column=0, row=0, padx=3)
-		self.box = ttk.Combobox(self.fix1, values=self.select_camera_list.keys(), state='readonly',
+		if sys.version_info[0] == 2:
+			self.box = ttk.Combobox(self.fix1, values=self.select_camera_list.keys(), state='readonly',
+												width=30, height=2)
+		else:
+			self.box = ttk.Combobox(self.fix1, values=list(self.select_camera_list.keys()), state='readonly',
 												width=30, height=2)
 		self.box.grid(column=1, row=0, padx=3, pady=3)
 		self.box.bind("<<ComboboxSelected>>", self.change_camera)


### PR DESCRIPTION
tkcalibuig's RTM logo image creation logic error in python3 was corrected.

"str" and "bytes" are strictly distinguished on python3.
"bytes" cannot concatenate by "+" method, instead of "+" method, "join" method was applied to the image bytes sequence.
This works on both python2 and python3.

- [x] Did you succesed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
