### PR TITLE
masterブランチのバージョン番号修正（1.2.3）

### DIFF
--- a/opencv/CMakeLists.txt
+++ b/opencv/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5.1)
 
-project(ImageProcessing VERSION 1.2.2)
+project(ImageProcessing VERSION 1.2.3)
 set(TOP_PROJECT_NAME ${PROJECT_NAME})
 string(TOLOWER ${TOP_PROJECT_NAME} TOP_PROJECT_NAME_LOWER)
 SUBDIRS(components)


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Link to #30 


## Description of the Change
- ImageProcessing全体のバージョン番号を 1.2.3 へ更新した
- この変更により、Linux環境で下記ファイル名のdebパッケージが生成される
「imageprocessing_1.2.3_amd64.deb」
- インストール先は /usr/share/openrtm-1.2 であることを確認



## Verification 



- [x] Did you succesed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
